### PR TITLE
Fix for loads false positive

### DIFF
--- a/dependency-check/false-positives.xml
+++ b/dependency-check/false-positives.xml
@@ -16,13 +16,18 @@
         <vulnerabilityName>CVE-2023-26115</vulnerabilityName>
     </suppress>
     <suppress>
+        <notes><![CDATA[file name: index.js]]></notes>
+        <packageUrl regex="true">^pkg:javascript/lodash@.*$</packageUrl>
+        <cve>CVE-2019-10744</cve>
+    </suppress>
+    <suppress>
         <notes><![CDATA[file name: ejs:3.1.9]]></notes>
         <packageUrl regex="true">^pkg:npm/ejs@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-29827</vulnerabilityName>
     </suppress>
     <suppress base="true">
-       <notes><![CDATA[FP per issue #4525]]></notes>
-       <packageUrl regex="true">^pkg:npm/opener@.*$</packageUrl>
-       <cpe>cpe:/a:opener_project:opener</cpe>
+        <notes><![CDATA[FP per issue #4525]]></notes>
+        <packageUrl regex="true">^pkg:npm/opener@.*$</packageUrl>
+        <cpe>cpe:/a:opener_project:opener</cpe>
     </suppress>
 </suppressions>

--- a/dependency-check/false-positives.xml
+++ b/dependency-check/false-positives.xml
@@ -18,7 +18,13 @@
     <suppress>
         <notes><![CDATA[file name: index.js]]></notes>
         <packageUrl regex="true">^pkg:javascript/lodash@.*$</packageUrl>
+        <cve>CVE-2018-16487</cve>
+        <cve>CVE-2018-3721</cve>
+        <cve>CVE-2019-1010266</cve>
         <cve>CVE-2019-10744</cve>
+        <cve>CVE-2020-28500</cve>
+        <cve>CVE-2020-8203</cve>
+        <cve>CVE-2021-23337</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[file name: ejs:3.1.9]]></notes>


### PR DESCRIPTION
Lodash 4.0.1 is an older package containing numerous vulnerabilities. 

We do not use this package version, but lodash internally uses a module export from it (lodash.isstring). 

Researching this module export, it has no known vulnerabilities and it is the latest compatible version. Given this evidence of false positive, I have suppressed the related issues as indicated in this PR.

Indicates the submodule lodash.isstring.
![Screenshot 2024-01-17 at 12 01 54 PM](https://github.com/Athian-ai/public/assets/7361936/5a9b0e3e-6eb3-4979-b663-263fe936df62)

Package health indicating no known vulnerabilities.
![Screenshot 2024-01-17 at 12 02 56 PM](https://github.com/Athian-ai/public/assets/7361936/139cb7b9-8743-46bc-b5af-5dcc625ad86d)