### PR TITLE
Add vulnerability names to temp suppressions

### DIFF
--- a/dependency-check/false-positives.xml
+++ b/dependency-check/false-positives.xml
@@ -67,20 +67,24 @@
         <notes><![CDATA[file name: tar:4.4.19]]></notes>
         <packageUrl regex="true">^pkg:npm/tar@.*$</packageUrl>
         <cpe>cpe:/a:tar_project:tar</cpe>
+        <vulnerabilityName>GHSA-f5x3-32g6-xq36</vulnerabilityName>
     </suppress>
     <suppress>
         <notes><![CDATA[file name: fast-xml-parser:4.2.5]]></notes>
         <packageUrl regex="true">^pkg:npm/fast-xml-parser@.*$</packageUrl>
         <cpe>cpe:/a:fast-xml-parser_project:fast-xml-parser</cpe>
+        <vulnerabilityName>GHSA-mpg4-rc92-vx8v</vulnerabilityName>
     </suppress>
     <suppress>
         <notes><![CDATA[file name: async:3.2.5]]></notes>
         <packageUrl regex="true">^pkg:npm/async@.*$</packageUrl>
         <cpe>cpe:/a:async_project:async</cpe>
+        <vulnerabilityName>CVE-2024-39249</vulnerabilityName>
     </suppress>
     <suppress>
         <notes><![CDATA[file name: async:2.6.4]]></notes>
         <packageUrl regex="true">^pkg:npm/async@.*$</packageUrl>
         <cpe>cpe:/a:async_project:async</cpe>
+        <vulnerabilityName>CVE-2024-39249</vulnerabilityName>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Not 100% sure we can just add the vulnerability name to the same suppression, but looked like there were two suppressions to make for each vulnerability